### PR TITLE
Let flake8 pull a version of pep8 it requires

### DIFF
--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,5 +1,4 @@
 coverage
 flake8
 nose
-pep8
 six

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,6 @@ envlist = py27, py33, py34
 [testenv]
 deps = 
     nose
-    pep8
     coverage
     flake8
     six


### PR DESCRIPTION
flake8-2.4.0 does not support pep8>=1.6.0 which resulted in dependency conflict with the latest stable 1.6.2 pulled in explicitly