### PR TITLE
docstring: Add decorator to format the docstrings

### DIFF
--- a/ddt.py
+++ b/ddt.py
@@ -145,6 +145,15 @@ def feed_data(func, new_name, *args, **kwargs):
     def wrapper(self):
         return func(self, *args, **kwargs)
     wrapper.__name__ = new_name
+    # Try to call format on the docstring
+    if func.__doc__:
+        try:
+            wrapper.__doc__ = func.__doc__.format(*args, **kwargs)
+        except (IndexError, KeyError):
+            # Maybe the user has added some of the formating strings
+            # unintentionally in the docstring. Do not raise an exception as it
+            # could be that he is not aware of the formating feature.
+            pass
     return wrapper
 
 

--- a/test/test_example.py
+++ b/test/test_example.py
@@ -58,3 +58,24 @@ class FooTestCase(unittest.TestCase):
     @data(u'ascii', u'non-ascii-\N{SNOWMAN}')
     def test_unicode(self, value):
         self.assertIn(value, (u'ascii', u'non-ascii-\N{SNOWMAN}'))
+
+    @data(3, 4, 12, 23)
+    def test_larger_than_two_with_doc(self, value):
+        """Larger than two with value {0}"""
+        self.assertTrue(larger_than_two(value))
+
+    @data(3, 4, 12, 23)
+    def test_doc_missing_args(self, value):
+        """Missing args with value {0} and {1}"""
+        self.assertTrue(larger_than_two(value))
+
+    @data(3, 4, 12, 23)
+    def test_doc_missing_kargs(self, value):
+        """Missing kargs with value {value} {value2}"""
+        self.assertTrue(larger_than_two(value))
+
+    @data([3, 2], [4, 3], [5, 3])
+    @unpack
+    def test_list_extracted_with_doc(self, first_value, second_value):
+        """Extract into args with first value {} and second value {}"""
+        self.assertTrue(first_value > second_value)


### PR DESCRIPTION
Some test frameworks like nose use the docstring to output information
about a test. In the case of generated tests all of them would get the
same description. Format the docstring for each generated test function using the test values.

Example:

@data(1,2)
def test_A(value):
    """Test A for value {}"""
    ...

executed with "nosetests -v", will output:
Test A for value 1
Test A for value 2

Signed-off-by: domidimi@github.com