### PR TITLE
specify minimum version of six

### DIFF
--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -2,4 +2,4 @@ codecov
 coverage
 flake8
 nose
-six
+six>=1.4.0

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@ deps =
     nose
     coverage
     flake8
-    six
+    six>=1.4.0
 commands = 
     nosetests -s --with-coverage --cover-package=ddt --cover-html
     flake8 ddt.py test


### PR DESCRIPTION
In `test/test_functional.py`, the attribute `six.PY2` is used.  This wasn't added to six until version 1.4.0.