### PR TITLE
Add basic support for YAML data files

### DIFF
--- a/ddt.py
+++ b/ddt.py
@@ -173,16 +173,20 @@ def process_file_data(cls, name, func, file_attr):
         add_test(cls, test_name, _raise_not_exists_error, None)
         return
 
-    # Load the data as YAML or JSON
-    if data_file_path.endswith((".yml", ".yaml")):
-        # Don't have YAML but want to use YAML file.
-        if not _have_yaml:
-            test_name = mk_test_name(name, "error")
-            add_test(cls, test_name, _raise_need_yaml_error, None)
-            return
-        data = yaml.load(open(data_file_path).read())
-    else:
-        data = json.loads(open(data_file_path).read())
+    _is_yaml_file = data_file_path.endswith((".yml", ".yaml"))
+
+    # Don't have YAML but want to use YAML file.
+    if _is_yaml_file and not _have_yaml:
+        test_name = mk_test_name(name, "error")
+        add_test(cls, test_name, _raise_need_yaml_error, None)
+        return
+
+    with open(data_file_path) as f:
+        # Load the data from YAML or JSON
+        if _is_yaml_file:
+            data = yaml.load(f)
+        else:
+            data = json.load(f)
 
     # Add tests from data
     for i, elem in enumerate(data):

--- a/ddt.py
+++ b/ddt.py
@@ -13,7 +13,7 @@ from functools import wraps
 
 try:
     import yaml
-except Exception:
+except ImportError:  # pragma: no cover
     _have_yaml = False
 else:
     _have_yaml = True

--- a/ddt.py
+++ b/ddt.py
@@ -188,7 +188,14 @@ def process_file_data(cls, name, func, file_attr):
         else:
             data = json.load(f)
 
-    # Add tests from data
+    _add_tests_from_data(cls, name, func, data)
+
+
+def _add_tests_from_data(cls, name, func, data):
+    """
+    Add tests from data loaded from the data file into the class
+
+    """
     for i, elem in enumerate(data):
         if isinstance(data, dict):
             key, value = elem, data[elem]

--- a/ddt.py
+++ b/ddt.py
@@ -184,7 +184,7 @@ def process_file_data(cls, name, func, file_attr):
     with open(data_file_path) as f:
         # Load the data from YAML or JSON
         if _is_yaml_file:
-            data = yaml.load(f)
+            data = yaml.safe_load(f)
         else:
             data = json.load(f)
 

--- a/ddt.py
+++ b/ddt.py
@@ -163,7 +163,9 @@ def process_file_data(cls, name, func, file_attr):
         raise ValueError("%s does not exist" % file_attr)
 
     def _raise_need_yaml_error(*args):  # pylint: disable-msg=W0613
-        raise ValueError("%s is a YAML file, please install PyYAML" % file_attr)
+        raise ValueError(
+            "%s is a YAML file, please install PyYAML" % file_attr
+        )
 
     # If file does not exist, provide an error function instead
     if os.path.exists(data_file_path) is False:

--- a/docs/example.rst
+++ b/docs/example.rst
@@ -5,7 +5,12 @@ DDT consists of a class decorator ``ddt`` (for your ``TestCase`` subclass)
 and two method decorators (for your tests that want to be multiplied):
 
 * ``data``: contains as many arguments as values you want to feed to the test.
-* ``file_data``: will load test data from a JSON file.
+* ``file_data``: will load test data from a JSON or YAML file.
+
+.. note::
+
+   Only files ending with ".yml" and ".yaml" are loaded as YAML files. All
+   other files are loaded as JSON files.
 
 Normally each value within ``data`` will be passed as a single argument to
 your test method. If these values are e.g. tuples, you will have to unpack them
@@ -28,6 +33,14 @@ and ``test_data_list.json``:
 
 .. literalinclude:: ../test/test_data_list.json
    :language: javascript
+
+.. literalinclude:: ../test/test_data_dict.yaml
+   :language: yaml
+
+and ``test_data_list.yaml``:
+
+.. literalinclude:: ../test/test_data_list.yaml
+   :language: yaml
 
 And then run them with your favourite test runner, e.g. if you use nose::
 

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -3,3 +3,4 @@ coverage
 flake8
 nose
 six>=1.4.0
+PyYAML

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -4,3 +4,4 @@ flake8
 nose
 six>=1.4.0
 PyYAML
+mock

--- a/test/test_data_dict.yaml
+++ b/test/test_data_dict.yaml
@@ -1,0 +1,6 @@
+unsorted_list:
+  - 10
+  - 15
+  - 12
+
+sorted_list: [ 15, 12, 50 ]

--- a/test/test_data_dict_dict.yaml
+++ b/test/test_data_dict_dict.yaml
@@ -1,0 +1,19 @@
+positive_integer_range:
+    start: 0
+    end: 2
+    value: 1
+
+negative_integer_range:
+    start: -2
+    end: 0
+    value: -1
+
+positive_real_range:
+    start: 0.0
+    end: 1.0
+    value: 0.5
+
+negative_real_range:
+    start: -1.0
+    end: 0.0
+    value: -0.5

--- a/test/test_data_list.yaml
+++ b/test/test_data_list.yaml
@@ -1,0 +1,2 @@
+- "Hello"
+- "Goodbye"

--- a/test/test_example.py
+++ b/test/test_example.py
@@ -2,6 +2,17 @@ import unittest
 from ddt import ddt, data, file_data, unpack
 from test.mycode import larger_than_two, has_three_elements, is_a_greeting
 
+try:
+    import yaml
+except Exception:
+    do_not_have_yaml_support = True
+else:
+    do_not_have_yaml_support = False
+    del yaml
+
+# A good-looking decorator
+needs_yaml = unittest.skipIf(do_not_have_yaml_support, "Need YAML to run this test")
+
 
 class Mylist(list):
     pass
@@ -32,17 +43,34 @@ class FooTestCase(unittest.TestCase):
         self.assertGreater(a, b)
 
     @file_data("test_data_dict_dict.json")
-    def test_file_data_dict_dict(self, start, end, value):
+    def test_file_data_json_dict_dict(self, start, end, value):
         self.assertLess(start, end)
         self.assertLess(value, end)
         self.assertGreater(value, start)
 
     @file_data('test_data_dict.json')
-    def test_file_data_dict(self, value):
+    def test_file_data_json_dict(self, value):
         self.assertTrue(has_three_elements(value))
 
     @file_data('test_data_list.json')
-    def test_file_data_list(self, value):
+    def test_file_data_json_list(self, value):
+        self.assertTrue(is_a_greeting(value))
+
+    @needs_yaml
+    @file_data("test_data_dict_dict.yaml")
+    def test_file_data_yaml_dict_dict(self, start, end, value):
+        self.assertLess(start, end)
+        self.assertLess(value, end)
+        self.assertGreater(value, start)
+
+    @needs_yaml
+    @file_data('test_data_dict.yaml')
+    def test_file_data_yaml_dict(self, value):
+        self.assertTrue(has_three_elements(value))
+
+    @needs_yaml
+    @file_data('test_data_list.yaml')
+    def test_file_data_yaml_list(self, value):
         self.assertTrue(is_a_greeting(value))
 
     @data((3, 2), (4, 3), (5, 3))

--- a/test/test_example.py
+++ b/test/test_example.py
@@ -11,7 +11,9 @@ else:
     del yaml
 
 # A good-looking decorator
-needs_yaml = unittest.skipIf(do_not_have_yaml_support, "Need YAML to run this test")
+needs_yaml = unittest.skipIf(
+    do_not_have_yaml_support, "Need YAML to run this test"
+)
 
 
 class Mylist(list):

--- a/test/test_example.py
+++ b/test/test_example.py
@@ -5,14 +5,14 @@ from test.mycode import larger_than_two, has_three_elements, is_a_greeting
 try:
     import yaml
 except Exception:
-    do_not_have_yaml_support = True
+    have_yaml_support = False
 else:
-    do_not_have_yaml_support = False
+    have_yaml_support = True
     del yaml
 
 # A good-looking decorator
-needs_yaml = unittest.skipIf(
-    do_not_have_yaml_support, "Need YAML to run this test"
+needs_yaml = unittest.skipUnless(
+    have_yaml_support, "Need YAML to run this test"
 )
 
 

--- a/test/test_example.py
+++ b/test/test_example.py
@@ -4,7 +4,7 @@ from test.mycode import larger_than_two, has_three_elements, is_a_greeting
 
 try:
     import yaml
-except Exception:
+except ImportError:  # pragma: no cover
     have_yaml_support = False
 else:
     have_yaml_support = True

--- a/test/test_functional.py
+++ b/test/test_functional.py
@@ -2,16 +2,12 @@ import os
 import json
 
 import six
+import mock
 
 from ddt import ddt, data, file_data
 from nose.tools import assert_equal, assert_is_not_none, assert_raises
 
 from test.mycode import has_three_elements
-
-try:
-    from unittest import mock
-except ImportError:
-    import mock
 
 
 @ddt

--- a/test/test_functional.py
+++ b/test/test_functional.py
@@ -62,7 +62,7 @@ class JSONFileDataMissingDummy(object):
 class YAMLFileDataMissingDummy(object):
     """
     Dummy class to test the file_data decorator on when
-    JSON file is missing
+    YAML file is missing
     """
 
     @file_data("test_data_dict_missing.yaml")

--- a/test/test_functional.py
+++ b/test/test_functional.py
@@ -6,6 +6,13 @@ import six
 from ddt import ddt, data, file_data
 from nose.tools import assert_equal, assert_is_not_none, assert_raises
 
+from test.mycode import has_three_elements
+
+try:
+    from unittest import mock
+except ImportError:
+    import mock
+
 
 @ddt
 class Dummy(object):
@@ -42,13 +49,25 @@ class FileDataDummy(object):
 
 
 @ddt
-class FileDataMissingDummy(object):
+class JSONFileDataMissingDummy(object):
     """
     Dummy class to test the file_data decorator on when
     JSON file is missing
     """
 
     @file_data("test_data_dict_missing.json")
+    def test_something_again(self, value):
+        return value
+
+
+@ddt
+class YAMLFileDataMissingDummy(object):
+    """
+    Dummy class to test the file_data decorator on when
+    JSON file is missing
+    """
+
+    @file_data("test_data_dict_missing.yaml")
     def test_something_again(self, value):
         return value
 
@@ -170,11 +189,23 @@ def test_feed_data_file_data():
 
 def test_feed_data_file_data_missing_json():
     """
-    Test that a ValueError is raised
+    Test that a ValueError is raised when JSON file is missing
     """
-    tests = filter(_is_test, FileDataMissingDummy.__dict__)
+    tests = filter(_is_test, JSONFileDataMissingDummy.__dict__)
 
-    obj = FileDataMissingDummy()
+    obj = JSONFileDataMissingDummy()
+    for test in tests:
+        method = getattr(obj, test)
+        assert_raises(ValueError, method)
+
+
+def test_feed_data_file_data_missing_yaml():
+    """
+    Test that a ValueError is raised when YAML file is missing
+    """
+    tests = filter(_is_test, YAMLFileDataMissingDummy.__dict__)
+
+    obj = YAMLFileDataMissingDummy()
     for test in tests:
         method = getattr(obj, test)
         assert_raises(ValueError, method)
@@ -270,3 +301,14 @@ def test_feed_data_with_invalid_identifier():
         'test_data_with_invalid_identifier_1_32v2_g__Gmw845h_W_b53wi_'
     )
     assert_equal(method(), '32v2 g #Gmw845h$W b53wi.')
+
+
+@mock.patch('ddt._have_yaml', False)
+def test_load_yaml_without_yaml_support():
+    """
+    Test that YAML files are not loaded if YAML is not installed.
+    """
+
+    @file_data('test_data_dict.yaml')
+    def test_file_data_yaml_dict(value):
+        self.assertTrue(has_three_elements(value))

--- a/test/test_functional.py
+++ b/test/test_functional.py
@@ -5,7 +5,9 @@ import six
 import mock
 
 from ddt import ddt, data, file_data
-from nose.tools import assert_equal, assert_is_not_none, assert_raises
+from nose.tools import (
+    assert_true, assert_equal, assert_is_not_none, assert_raises
+)
 
 from test.mycode import has_three_elements
 
@@ -307,4 +309,4 @@ def test_load_yaml_without_yaml_support():
 
     @file_data('test_data_dict.yaml')
     def test_file_data_yaml_dict(value):
-        self.assertTrue(has_three_elements(value))
+        assert_true(has_three_elements(value))

--- a/test/test_functional.py
+++ b/test/test_functional.py
@@ -307,6 +307,16 @@ def test_load_yaml_without_yaml_support():
     Test that YAML files are not loaded if YAML is not installed.
     """
 
-    @file_data('test_data_dict.yaml')
-    def test_file_data_yaml_dict(value):
-        assert_true(has_three_elements(value))
+    @ddt
+    class NoYAMLInstalledTest(object):
+
+        @file_data('test_data_dict.yaml')
+        def test_file_data_yaml_dict(self, value):
+            assert_true(has_three_elements(value))
+
+    tests = filter(_is_test, NoYAMLInstalledTest.__dict__)
+
+    obj = NoYAMLInstalledTest()
+    for test in tests:
+        method = getattr(obj, test)
+        assert_raises(ValueError, method)


### PR DESCRIPTION
Add support for YAML files, when PyYAML is installed. If PyYAML is not
installed, any YAML file_data functions error out.

Only files ending with .yml or .yaml are considered to be YAML files.
All other files are loaded as JSON files.