### PR TITLE
Set __wrapped__ for Python 2

### DIFF
--- a/ddt.py
+++ b/ddt.py
@@ -138,6 +138,7 @@ def feed_data(func, new_name, *args, **kwargs):
     def wrapper(self):
         return func(self, *args, **kwargs)
     wrapper.__name__ = new_name
+    wrapper.__wrapped__ = func
     # Try to call format on the docstring
     if func.__doc__:
         try:


### PR DESCRIPTION
This makes ddt work like Python 3's functools.wraps, and also like mock on both Python 2 and Python 3.

I've been working on a nose plugin to clear attributes that might be leaking memory, and this makes it possible.