### PR TITLE
Use raw string for regex

### DIFF
--- a/ddt.py
+++ b/ddt.py
@@ -126,7 +126,7 @@ def mk_test_name(name, value, index=0):
         # fallback for python2
         value = value.encode('ascii', 'backslashreplace')
     test_name = "{0}_{1}_{2}".format(name, index + 1, value)
-    return re.sub('\W|^(?=\d)', '_', test_name)
+    return re.sub(r'\W|^(?=\d)', '_', test_name)
 
 
 def feed_data(func, new_name, *args, **kwargs):


### PR DESCRIPTION
This issues a DeprecationWarning on python 3.6
due to \W not being a valid escape character in
regular strings.