### PR TITLE
Add zeros to test_names to fix the running order.

### DIFF
--- a/ddt.py
+++ b/ddt.py
@@ -27,6 +27,8 @@ __version__ = '1.1.1'
 DATA_ATTR = '%values'      # store the data the test must run with
 FILE_ATTR = '%file_path'   # store the path to JSON file
 UNPACK_ATTR = '%unpack'    # remember that we have to unpack values
+# Digits of the largest index of cases for list/tuple, or default = 5 for generator
+INDEX_LEN = len(str(len(DATA_ATTR))) if isinstance(DATA_ATTR, (list, tuple)) else 5
 
 
 try:
@@ -118,14 +120,18 @@ def mk_test_name(name, value, index=0):
     only of trivial values.
     """
 
+    # Add zeros before index to keep order
+    index = str(index + 1)
+    if len(index) < INDEX_LEN:
+        index = '0' * (INDEX_LEN - len(index)) + index
     if not is_trivial(value):
-        return "{0}_{1}".format(name, index + 1)
+        return "{0}_{1}".format(name, index)
     try:
         value = str(value)
     except UnicodeEncodeError:
         # fallback for python2
         value = value.encode('ascii', 'backslashreplace')
-    test_name = "{0}_{1}_{2}".format(name, index + 1, value)
+    test_name = "{0}_{1}_{2}".format(name, index, value)
     return re.sub(r'\W|^(?=\d)', '_', test_name)
 
 

--- a/ddt.py
+++ b/ddt.py
@@ -27,8 +27,7 @@ __version__ = '1.1.1'
 DATA_ATTR = '%values'      # store the data the test must run with
 FILE_ATTR = '%file_path'   # store the path to JSON file
 UNPACK_ATTR = '%unpack'    # remember that we have to unpack values
-# Digits of the largest index for list/tuple, or default = 5 for generator
-I_LEN = len(str(len(DATA_ATTR))) if isinstance(DATA_ATTR, (list, tuple)) else 5
+index_len = 5              # default max length of case index
 
 
 try:
@@ -61,6 +60,8 @@ def data(*values):
     Should be added to methods of instances of ``unittest.TestCase``.
 
     """
+    global index_len
+    index_len = len(values)
     return idata(values)
 
 
@@ -121,9 +122,7 @@ def mk_test_name(name, value, index=0):
     """
 
     # Add zeros before index to keep order
-    index = str(index + 1)
-    if len(index) < I_LEN:
-        index = '0' * (I_LEN - len(index)) + index
+    index = "{0:0{1}}".format(index + 1, index_len)
     if not is_trivial(value):
         return "{0}_{1}".format(name, index)
     try:

--- a/ddt.py
+++ b/ddt.py
@@ -27,8 +27,8 @@ __version__ = '1.1.1'
 DATA_ATTR = '%values'      # store the data the test must run with
 FILE_ATTR = '%file_path'   # store the path to JSON file
 UNPACK_ATTR = '%unpack'    # remember that we have to unpack values
-# Digits of the largest index of cases for list/tuple, or default = 5 for generator
-INDEX_LEN = len(str(len(DATA_ATTR))) if isinstance(DATA_ATTR, (list, tuple)) else 5
+# Digits of the largest index for list/tuple, or default = 5 for generator
+I_LEN = len(str(len(DATA_ATTR))) if isinstance(DATA_ATTR, (list, tuple)) else 5
 
 
 try:
@@ -122,8 +122,8 @@ def mk_test_name(name, value, index=0):
 
     # Add zeros before index to keep order
     index = str(index + 1)
-    if len(index) < INDEX_LEN:
-        index = '0' * (INDEX_LEN - len(index)) + index
+    if len(index) < I_LEN:
+        index = '0' * (I_LEN - len(index)) + index
     if not is_trivial(value):
         return "{0}_{1}".format(name, index)
     try:

--- a/ddt.py
+++ b/ddt.py
@@ -61,7 +61,7 @@ def data(*values):
 
     """
     global index_len
-    index_len = len(values)
+    index_len = len(str(len(values)))
     return idata(values)
 
 

--- a/test/test_functional.py
+++ b/test/test_functional.py
@@ -256,8 +256,7 @@ def test_ddt_data_unicode():
                 pass
 
         assert_is_not_none(getattr(Mytest, 'test_hello_1_ascii'))
-        assert_is_not_none(getattr
-                           (Mytest, 'test_hello_2_non_ascii__u2603'))
+        assert_is_not_none(getattr(Mytest, 'test_hello_2_non_ascii__u2603'))
         assert_is_not_none(getattr(Mytest, 'test_hello_3'))
 
     elif six.PY3:

--- a/test/test_functional.py
+++ b/test/test_functional.py
@@ -148,8 +148,8 @@ def test_file_data_test_names_dict():
     test_data_path = os.path.join(tests_dir, 'test_data_dict.json')
     test_data = json.loads(open(test_data_path).read())
     created_tests = set([
-        "test_something_again_{0}_{1}".format(
-        	'0' * (5 - len(str(index + 1))) + str(index + 1), name)
+        "test_something_again_{0}_{1}".format
+        ('0' * (5 - len(str(index + 1))) + str(index + 1), name)
         for index, name in enumerate(test_data.keys())
     ])
 
@@ -256,7 +256,8 @@ def test_ddt_data_unicode():
                 pass
 
         assert_is_not_none(getattr(Mytest, 'test_hello_00001_ascii'))
-        assert_is_not_none(getattr(Mytest, 'test_hello_00002_non_ascii__u2603'))
+        assert_is_not_none(getattr
+                           (Mytest, 'test_hello_00002_non_ascii__u2603'))
         assert_is_not_none(getattr(Mytest, 'test_hello_00003'))
 
     elif six.PY3:
@@ -267,9 +268,9 @@ def test_ddt_data_unicode():
             def test_hello(self, val):
                 pass
 
-        assert_is_not_none(getattr(Mytest, 'test_hello_1_ascii'))
-        assert_is_not_none(getattr(Mytest, 'test_hello_2_non_ascii__'))
-        assert_is_not_none(getattr(Mytest, 'test_hello_3'))
+        assert_is_not_none(getattr(Mytest, 'test_hello_00001_ascii'))
+        assert_is_not_none(getattr(Mytest, 'test_hello_00002_non_ascii__'))
+        assert_is_not_none(getattr(Mytest, 'test_hello_00003'))
 
 
 def test_ddt_data_object():

--- a/test/test_functional.py
+++ b/test/test_functional.py
@@ -255,7 +255,6 @@ def test_ddt_data_unicode():
             def test_hello(self, val):
                 pass
 
-        print(Mytest.__dict__)
         assert_is_not_none(getattr(Mytest, 'test_hello_1_ascii'))
         assert_is_not_none(getattr
                            (Mytest, 'test_hello_2_non_ascii__u2603'))

--- a/test/test_functional.py
+++ b/test/test_functional.py
@@ -233,8 +233,8 @@ def test_ddt_data_name_attribute():
     setattr(Mytest, 'test_hello', data_hello)
 
     ddt_mytest = ddt(Mytest)
-    assert_is_not_none(getattr(ddt_mytest, 'test_hello_00001_data1'))
-    assert_is_not_none(getattr(ddt_mytest, 'test_hello_00002_2'))
+    assert_is_not_none(getattr(ddt_mytest, 'test_hello_1_data1'))
+    assert_is_not_none(getattr(ddt_mytest, 'test_hello_2_2'))
 
 
 def test_ddt_data_unicode():
@@ -255,10 +255,10 @@ def test_ddt_data_unicode():
             def test_hello(self, val):
                 pass
 
-        assert_is_not_none(getattr(Mytest, 'test_hello_00001_ascii'))
+        assert_is_not_none(getattr(Mytest, 'test_hello_1_ascii'))
         assert_is_not_none(getattr
-                           (Mytest, 'test_hello_00002_non_ascii__u2603'))
-        assert_is_not_none(getattr(Mytest, 'test_hello_00003'))
+                           (Mytest, 'test_hello_2_non_ascii__u2603'))
+        assert_is_not_none(getattr(Mytest, 'test_hello_3'))
 
     elif six.PY3:
 
@@ -268,9 +268,9 @@ def test_ddt_data_unicode():
             def test_hello(self, val):
                 pass
 
-        assert_is_not_none(getattr(Mytest, 'test_hello_00001_ascii'))
-        assert_is_not_none(getattr(Mytest, 'test_hello_00002_non_ascii__'))
-        assert_is_not_none(getattr(Mytest, 'test_hello_00003'))
+        assert_is_not_none(getattr(Mytest, 'test_hello_1_ascii'))
+        assert_is_not_none(getattr(Mytest, 'test_hello_2_non_ascii__'))
+        assert_is_not_none(getattr(Mytest, 'test_hello_3'))
 
 
 def test_ddt_data_object():
@@ -284,7 +284,7 @@ def test_ddt_data_object():
         def test_object(self, val):
             pass
 
-    assert_is_not_none(getattr(Mytest, 'test_object_00001'))
+    assert_is_not_none(getattr(Mytest, 'test_object_1'))
 
 
 def test_feed_data_with_invalid_identifier():
@@ -298,7 +298,7 @@ def test_feed_data_with_invalid_identifier():
     method = getattr(obj, tests[0])
     assert_equal(
         method.__name__,
-        'test_data_with_invalid_identifier_00001_32v2_g__Gmw845h_W_b53wi_'
+        'test_data_with_invalid_identifier_1_32v2_g__Gmw845h_W_b53wi_'
     )
     assert_equal(method(), '32v2 g #Gmw845h$W b53wi.')
 

--- a/test/test_functional.py
+++ b/test/test_functional.py
@@ -147,9 +147,9 @@ def test_file_data_test_names_dict():
     tests_dir = os.path.dirname(__file__)
     test_data_path = os.path.join(tests_dir, 'test_data_dict.json')
     test_data = json.loads(open(test_data_path).read())
+    index_len = len(str(len(test_data)))
     created_tests = set([
-        "test_something_again_{0}_{1}".format
-        ('0' * (5 - len(str(index + 1))) + str(index + 1), name)
+        "test_something_again_{0:0{2}}_{1}".format(index + 1, name, index_len)
         for index, name in enumerate(test_data.keys())
     ])
 
@@ -255,6 +255,7 @@ def test_ddt_data_unicode():
             def test_hello(self, val):
                 pass
 
+        print(Mytest.__dict__)
         assert_is_not_none(getattr(Mytest, 'test_hello_1_ascii'))
         assert_is_not_none(getattr
                            (Mytest, 'test_hello_2_non_ascii__u2603'))

--- a/test/test_functional.py
+++ b/test/test_functional.py
@@ -148,7 +148,8 @@ def test_file_data_test_names_dict():
     test_data_path = os.path.join(tests_dir, 'test_data_dict.json')
     test_data = json.loads(open(test_data_path).read())
     created_tests = set([
-        "test_something_again_{0}_{1}".format(index + 1, name)
+        "test_something_again_{0}_{1}".format(
+        	'0' * (5 - len(str(index + 1))) + str(index + 1), name)
         for index, name in enumerate(test_data.keys())
     ])
 
@@ -232,8 +233,8 @@ def test_ddt_data_name_attribute():
     setattr(Mytest, 'test_hello', data_hello)
 
     ddt_mytest = ddt(Mytest)
-    assert_is_not_none(getattr(ddt_mytest, 'test_hello_1_data1'))
-    assert_is_not_none(getattr(ddt_mytest, 'test_hello_2_2'))
+    assert_is_not_none(getattr(ddt_mytest, 'test_hello_00001_data1'))
+    assert_is_not_none(getattr(ddt_mytest, 'test_hello_00002_2'))
 
 
 def test_ddt_data_unicode():
@@ -254,9 +255,9 @@ def test_ddt_data_unicode():
             def test_hello(self, val):
                 pass
 
-        assert_is_not_none(getattr(Mytest, 'test_hello_1_ascii'))
-        assert_is_not_none(getattr(Mytest, 'test_hello_2_non_ascii__u2603'))
-        assert_is_not_none(getattr(Mytest, 'test_hello_3'))
+        assert_is_not_none(getattr(Mytest, 'test_hello_00001_ascii'))
+        assert_is_not_none(getattr(Mytest, 'test_hello_00002_non_ascii__u2603'))
+        assert_is_not_none(getattr(Mytest, 'test_hello_00003'))
 
     elif six.PY3:
 
@@ -282,7 +283,7 @@ def test_ddt_data_object():
         def test_object(self, val):
             pass
 
-    assert_is_not_none(getattr(Mytest, 'test_object_1'))
+    assert_is_not_none(getattr(Mytest, 'test_object_00001'))
 
 
 def test_feed_data_with_invalid_identifier():
@@ -296,7 +297,7 @@ def test_feed_data_with_invalid_identifier():
     method = getattr(obj, tests[0])
     assert_equal(
         method.__name__,
-        'test_data_with_invalid_identifier_1_32v2_g__Gmw845h_W_b53wi_'
+        'test_data_with_invalid_identifier_00001_32v2_g__Gmw845h_W_b53wi_'
     )
     assert_equal(method(), '32v2 g #Gmw845h$W b53wi.')
 


### PR DESCRIPTION
Add zeros to index in test_name to fix the running order when there are more than 9 cases.
Since `'_' > '9'`, `test_Case_1_*` will always run after `test_Case_19_*`, which is not expected.